### PR TITLE
Set Background Colors for Table Cells.

### DIFF
--- a/wiki/src/assets/global.css
+++ b/wiki/src/assets/global.css
@@ -7,7 +7,9 @@
   box-sizing: border-box;
 }
 
-html, body, #app {
+html,
+body,
+#app {
   height: 100%;
   font-family: 'Helvetica Neue', Arial, 'PingFang SC', 'Microsoft YaHei', sans-serif;
   background-color: #ffffff;
@@ -18,18 +20,24 @@ a {
   color: #0c64c1;
   text-decoration: none;
 }
+
 a:hover {
   text-decoration: underline;
 }
 
-h1, h2, h3, h4, h5 {
+h1,
+h2,
+h3,
+h4,
+h5 {
   font-weight: 600;
 }
 
 /* 让页面整体对齐中间 */
 .doc-content,
 .home-content {
-  margin-left: 240px; /* 留出侧边栏宽度 */
+  margin-left: 240px;
+  /* 留出侧边栏宽度 */
   max-width: 800px;
 }
 
@@ -39,16 +47,19 @@ blockquote {
   padding-left: 16px;
   color: #666;
 }
+
 table {
   border-collapse: collapse;
   width: 100%;
   margin: 1em 0;
 }
+
 table th,
 table td {
   border: 1px solid #ddd;
   padding: 8px;
 }
+
 table th {
   background-color: #f6f8fa;
 }

--- a/wiki/src/assets/global.css
+++ b/wiki/src/assets/global.css
@@ -58,6 +58,10 @@ table th,
 table td {
   border: 1px solid #ddd;
   padding: 8px;
+
+  /* Set the background color of table cells. */
+  --bgColor-default: #c6c6c6;
+  --bgColor-muted: #868686;
 }
 
 table th {


### PR DESCRIPTION
# Original Color

The original background colors of table cells are shown as below, which is unclear and don't align with the light theme.

<img width="910" height="656" alt="image" src="https://github.com/user-attachments/assets/5cca7356-bd38-4813-897d-2978d448462d" />

# Current Color

Image below shows the colors after modifying.

<img width="936" height="768" alt="image" src="https://github.com/user-attachments/assets/fcf148d8-2df1-4843-bcf9-28e5e7d12076" />
